### PR TITLE
Add sbin to PATH

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -56,3 +56,4 @@ PS1=$PS1"$WHITE]\n $WHITEBOLD\$$WHITE "
 # load exports and aliases files
 [[ -s "$HOME/.bash_exports" ]] && . "$HOME/.bash_exports"
 [[ -s "$HOME/.bash_aliases" ]] && . "$HOME/.bash_aliases"
+export PATH=/usr/local/sbin:$PATH


### PR DESCRIPTION
Some applications are installed on `/user/local/sbin`, so it need to be on $PATH.