### PR TITLE
Remove all source related to bash completion

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -24,12 +24,7 @@ source ~/.bash_colors
 export PATH="/usr/local/bin:$PATH:~/homebrew/bin"
 # rvm loader
 source_or_error ~/.rvm/scripts/rvm "No RVM installed"
-# bash completion
-source_or_error $(brew --prefix)/etc/bash_completion "No bash-completion installed"
-# git completion
-source_or_error $(brew --prefix)/etc/bash_completion.d/git-completion.bash "No git-completion installed"
-# git prompt
-source_or_error $(brew --prefix)/etc/bash_completion.d/git-prompt.sh "No git-prompt installed"
+
 # rvm function for ruby version
 if [ -s "$HOME/.rvm/bin/rvm-prompt" ]; then
   __rvm_ps1()


### PR DESCRIPTION
Since macOS 10.15, `zsh` is the default shell. Importing bash-completion gives an error.